### PR TITLE
use copy2, so the timestamp information is also copied

### DIFF
--- a/termux-apt-repo
+++ b/termux-apt-repo
@@ -40,7 +40,7 @@ def add_deb(deb_to_add_path):
     dest_deb_dir_path = component_path + '/binary-' + deb_arch
     if not os.path.isdir(dest_deb_dir_path): os.makedirs(dest_deb_dir_path)
     destination_deb_file = dest_deb_dir_path + '/' + os.path.basename(deb_to_add_path)
-    shutil.copy(deb_to_add_path, destination_deb_file)
+    shutil.copy2(deb_to_add_path, destination_deb_file)
 
 if len(sys.argv) == 3:
     input_path = sys.argv[1]


### PR DESCRIPTION
with copy, the deb files always have a new time stamp, which isn't useful if you sync e.g to amazon s3 or with rsync.