### PR TITLE
support data.tar.gz

### DIFF
--- a/termux-apt-repo
+++ b/termux-apt-repo
@@ -44,8 +44,26 @@ def control_file_contents(debfile):
     return contents
 
 def list_package_files(debfile):
+    file_list = run_shell_command("ar t {}".format(debfile))
+    if file_list is None:
+        sys.exit("Error listing contents of '{}'".format(debfile))
+
+    file_list = file_list.split("\n")
+
+    if "data.tar.gz" in file_list:
+        data_filename = "data.tar.gz"
+        tar_args = "-z"
+    elif "data.tar.xz" in file_list:
+        data_filename = "data.tar.xz"
+        tar_args = "-J"
+    else:
+        sys.exit("Failed to find control file in '{}'".format(debfile))
+
+    cmd_fmt = "ar p {} {} | tar -t {}"
+    cmd = cmd_fmt.format(debfile, data_filename, tar_args)
+
     all_content = subprocess.check_output(
-        ["ar p " + debfile + " data.tar.xz | tar -tJ"],
+        [cmd],
         shell=True,
         universal_newlines=True,
         stderr=subprocess.DEVNULL


### PR DESCRIPTION
I had a deb with `data.tar.gz` instead of `data.tar.xz` which caused an error.